### PR TITLE
guard extractErrorsFromMeta from undefined

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -125,6 +125,9 @@ class StackdriverErrorReporting extends Transport {
    * @return {Array}
    */
   extractErrorsFromMeta(data) {
+    if (!data) {
+      return [];
+    }
 
     let errors = [];
 


### PR DESCRIPTION
if a key was set to null in the winston logging metadata, the transport would throw an error.

eg: `winston.error('test error', { key: null })` would produce

```
TypeError: Cannot read property 'stack' of undefined
    at StackdriverErrorReporting.extractErrorsFromMeta (/app/node_modules/@findanyemail/winston-transport-stackdriver-error-reporting/lib/index.js:142:13)
    at value (/app/node_modules/@findanyemail/winston-transport-stackdriver-error-reporting/lib/index.js:146:37)
```
